### PR TITLE
Fix to frame rate issue (30-->100+) 

### DIFF
--- a/mapinfo.lua
+++ b/mapinfo.lua
@@ -37,7 +37,6 @@ local mapinfo = {
 	},
 
 	resources = {
-		splatDistrTex = "splatrep.png",
 		splatDetailTex = "Rock.png",
 		splatDetailNormalDiffuseAlpha = 1,
 		splatDetailNormalTex = {


### PR DESCRIPTION
 Fixed by removing a single line in mapinfo.lua.  Map seems to continue to have all advmapshading effects, without any performance issues.